### PR TITLE
Fix function call that breaks vimside on mac

### DIFF
--- a/autoload/vimside.vim
+++ b/autoload/vimside.vim
@@ -112,7 +112,7 @@ elseif !has("win32unix") && has("unix") && !has("macunix")
 elseif has('win16') || has('win32') || has('win64') || has('dos32')
   let g:vimside.os.kind = "mswin"
   let g:vimside.os.is_mswin = 1
-elseif has('macunix'
+elseif has('macunix')
   let g:vimside.os.kind = "macunix"
   let g:vimside.os.is_macunix = 1
 else


### PR DESCRIPTION
After running `:call vimside#StartEnsime()`, I got the error in the image below.. Traced it to a missing bracket :smile: 

![Screen Shot 2013-01-10 at 23 50 09](https://f.cloud.github.com/assets/648684/58759/8086b614-5b80-11e2-9597-ff547931fcbe.png)

First pull request of the year :dancer: 
